### PR TITLE
feat(motivational-message): add endpoint to fetch random message

### DIFF
--- a/src/api/motivational-message/controllers/motivational-message.js
+++ b/src/api/motivational-message/controllers/motivational-message.js
@@ -6,4 +6,16 @@
 
 const { createCoreController } = require('@strapi/strapi').factories;
 
-module.exports = createCoreController('api::motivational-message.motivational-message');
+module.exports = createCoreController('api::motivational-message.motivational-message', ({ strapi }) => ({
+  async random(ctx) {
+    const count = await strapi.entityService.count('api::motivational-message.motivational-message');
+    const randomIndex = Math.floor(Math.random() * count);
+    const randomMessage = await strapi.entityService.findMany('api::motivational-message.motivational-message', {
+      start: randomIndex,
+      limit: 1,
+    });
+
+    return randomMessage[0];
+  } 
+
+}));

--- a/src/api/motivational-message/routes/01-random.js
+++ b/src/api/motivational-message/routes/01-random.js
@@ -1,0 +1,9 @@
+module.exports = {
+    routes: [
+      { 
+        method: 'GET',
+        path: '/motivational-messages/random', 
+        handler: 'motivational-message.random',
+      },
+    ]
+  }


### PR DESCRIPTION
Add a new controller method to retrieve a random motivational message
from the database. Implement a GET route at /motivational-messages/random
to expose this functionality. This change enables clients to easily
access a random motivational message without fetching all entries.